### PR TITLE
Set project manager on project creation

### DIFF
--- a/rcos_io/db.py
+++ b/rcos_io/db.py
@@ -198,6 +198,27 @@ def get_semester_projects(
 
     return result["projects"]
 
+def add_project_lead(project_id: str, user_id: str):
+    query = gql(
+        """
+        mutation AddProject($id: uuid!, $owner_id: uuid!, $name: String!, $desc: String!) {
+            insert_projects(objects: [
+                { id: $id, owner_id: $owner_id, name: $name, description_markdown: $desc }
+            ]) {
+                returning {
+                    id
+                }
+            }
+        }
+    """
+    )
+
+    result = client.execute(
+        query,
+        variable_values={"id": id, "owner_id": owner_id, "name": name, "desc": desc},
+    )
+
+    return result["insert_projects"]
 
 def add_project(id: str, owner_id: str, name: str, desc: str):
     query = gql(
@@ -238,3 +259,25 @@ def get_meetings() -> List[Dict[str, Any]]:
     )
     result = client.execute(query)
     return result["meetings"]
+
+def add_project_lead(project_id: str, user_id: str, semester_id: str, credits: int):
+    query = gql("""
+        mutation AddEnrollment($project_id: uuid!, $user_id: uuid!, $semester_id: String!, $credits: Int!) {
+            insert_enrollments_one(object: {
+                is_project_lead: true,
+                user_id: $user_id,
+                project_id: $project_id,
+                semester_id: $semester_id,
+                credits: $credits
+            }) {
+                project_id
+            }
+        }
+    """)
+
+    result = client.execute(
+        query, 
+        variable_values={"project_id": project_id, "user_id": user_id, "semester_id": semester_id, "credits": credits},
+    )
+
+    return result["insert_enrollments_one"]

--- a/rcos_io/db.py
+++ b/rcos_io/db.py
@@ -129,6 +129,7 @@ def get_project(project_id: str) -> Dict[str, Any] | None:
                 id
                 description_markdown
                 enrollments {
+                    is_project_lead
                     user {
                         rcs_id
                         first_name

--- a/rcos_io/templates/projects/project.html
+++ b/rcos_io/templates/projects/project.html
@@ -18,26 +18,15 @@
 		<i>None yet!</i>
 	{% endif %}
 
+	<hr/>
 
 	<h3>Members</h3>
 	{% if project['enrollments'] is defined and project['enrollments']|length > 0 %}
 		{% for user in project['enrollments'] %}
-			<li>{{ user['user']['first_name'] }} {{ user['user']['last_name'] }} ({{ user['semester']['title'] }})</li>
+			<li>{{ user['user']['first_name'] }} {{ user['user']['last_name'] }} {{ "(Project Lead)" if user['is_project_lead'] else "" }}</li>
 		{% endfor %}
 	{% else %}
 		<i>None yet!</i>
 	{% endif %}
-	<!-- {% if project['enrollments'] is defined and project['enrollments']|length > 0 %}
-		{% for semester_title, semester in project['assignments'].items() %}
-			<h4>{{ semester_title }}</h4>
-			<ul>
-				{% for user in semester %}
-					<li>{{ user['user']['first_name'] }} {{ user['user']['last_name'] }} ({{ user['semester']['title'] }})</li>
-				{% endfor %}
-			</ul>
-		{% endfor %}
-	{% else %}
-		<i>None yet!</i>
-	{% endif %} -->
 </div>
 {% endblock %}

--- a/rcos_io/templates/projects/projects.html
+++ b/rcos_io/templates/projects/projects.html
@@ -12,7 +12,7 @@
 	<tr>
 		<td>
 			<h3>{{ project['name'] }}</h3>
-			<a href="{{ '/project/%s' % project['id'] }}">Go to...</a>
+			<a href="{{ '/projects/%s' % project['id'] }}">Go to...</a>
 		</td>
 	</tr>
 	{% endfor %}

--- a/rcos_io/views/projects.py
+++ b/rcos_io/views/projects.py
@@ -102,9 +102,12 @@ def add_project():
 def project(project_id: str):
     project = db.get_project(project_id)
 
-    print(project)
-
     if len(project) == 1:
         project = project[0]
+
+    current_semester = get_current_semester()
+
+    # parse out any project members that are *not* in the project this semester
+    project['enrollments'] = list(filter(lambda user: user['semester']['id'] == current_semester, project['enrollments']))
 
     return render_template("projects/project.html", project=project)

--- a/rcos_io/views/projects.py
+++ b/rcos_io/views/projects.py
@@ -85,6 +85,13 @@ def add_project():
             "returning"
         ]
 
+        #
+        #   TODO: send validation to Discord, validation panel in site
+        #
+
+        # mark the creator of the project as the project lead
+        db.add_project_lead(inserted_project[0]["id"], user["id"], get_current_semester(), 4)
+
         if len(inserted_project) > 0:
             return redirect("/project/%s" % (inserted_project[0]["id"]))
 

--- a/rcos_io/views/projects.py
+++ b/rcos_io/views/projects.py
@@ -37,15 +37,15 @@ def render_projects(projects: List[Any]):
 
 
 
-@bp.route("/<semester>")
-def semester_projects(semester: str = None):
-    """
-        Get all projects for a specific semester.
-    """
-    if semester == None:
-        return render_projects([], False)
+# @bp.route("/<semester>")
+# def semester_projects(semester: str = None):
+#     """
+#         Get all projects for a specific semester.
+#     """
+#     if semester == None:
+#         return render_projects([], False)
 
-    return render_projects(db.get_semester_projects(semester, False))
+#     return render_projects(db.get_semester_projects(semester, False))
 
 
 
@@ -102,19 +102,9 @@ def add_project():
 def project(project_id: str):
     project = db.get_project(project_id)
 
+    print(project)
+
     if len(project) == 1:
         project = project[0]
-
-        # get all semesters where the project had members
-    # semesters = set([ user['semester']['id'] for user in project['enrollments'] ])
-    # members_by_semester = {}
-
-    # for s in semesters:
-    #     members_by_semester[s] = []
-
-    # for user in project['enrollments']:
-    #     members_by_semester.get(user['semester']['id']).append(user)
-
-    # project['assignments'] = members_by_semester
 
     return render_template("projects/project.html", project=project)


### PR DESCRIPTION
On project creation, assign the creator of the project as the project manager by adding a row to the enrollments table with the necessary information (project id, user id, 4 credits, semester_id). 

This will need to be revised to support a stricter authentication scheme. In addition to this, we will need to revisit the Hasura call to modify the row *if* it already exists.

I also fixed the `project/` route being broken; the `/projects/<sem>` route has been commented out in favor of the `/projects/<project id>` route. The commented route will be replaced with a querystring.