### PR TITLE
Upsert project leads instead of insert

### DIFF
--- a/rcos_io/db.py
+++ b/rcos_io/db.py
@@ -263,14 +263,20 @@ def get_meetings() -> List[Dict[str, Any]]:
 
 def add_project_lead(project_id: str, user_id: str, semester_id: str, credits: int):
     query = gql("""
-        mutation AddEnrollment($project_id: uuid!, $user_id: uuid!, $semester_id: String!, $credits: Int!) {
-            insert_enrollments_one(object: {
-                is_project_lead: true,
-                user_id: $user_id,
-                project_id: $project_id,
-                semester_id: $semester_id,
-                credits: $credits
-            }) {
+        mutation AddProjectLead($project_id: uuid!, $user_id: uuid!, $semester_id: String!, $credits: Int!) {
+            insert_enrollments_one(
+                object: {
+                    is_project_lead: true,
+                    user_id: $user_id,
+                    project_id: $project_id,
+                    semester_id: $semester_id,
+                    credits: $credits
+                },  
+                on_conflict: {
+                    constraint: enrollments_pkey,
+                    update_columns: [ project_id ]
+                }
+            ) {
                 project_id
             }
         }

--- a/rcos_io/db.py
+++ b/rcos_io/db.py
@@ -274,7 +274,7 @@ def add_project_lead(project_id: str, user_id: str, semester_id: str, credits: i
                 },  
                 on_conflict: {
                     constraint: enrollments_pkey,
-                    update_columns: [ project_id ]
+                    update_columns: [ project_id, is_project_lead ]
                 }
             ) {
                 project_id

--- a/rcos_io/views/projects.py
+++ b/rcos_io/views/projects.py
@@ -93,7 +93,7 @@ def add_project():
         db.add_project_lead(inserted_project[0]["id"], user["id"], get_current_semester(), 4)
 
         if len(inserted_project) > 0:
-            return redirect("/project/%s" % (inserted_project[0]["id"]))
+            return redirect("/projects/%s" % (inserted_project[0]["id"]))
 
     return render_template("projects/add_project.html")
 


### PR DESCRIPTION
If a user is already a project lead and they create a new project, they will now be removed from that other project and added to the newly created one. Currently the system will throw an error that they are already enrolled; these changes will simply update which project they're a part of / leading.