### PR TITLE
Sanitize Markdown before rendering

### DIFF
--- a/rcos_io/templates/projects/project.html
+++ b/rcos_io/templates/projects/project.html
@@ -8,7 +8,9 @@
 	<blockquote class="blockquote">
 		<p>{{ project["short_description"] }}</p>
 	</blockquote>
-	<p>{{ project['description_markdown'] }}</p>
+	<div>
+		{{ full_description | safe }}
+	</div>
 
 	<h3>Stack</h3>
 	{% if project['tags'] is defined and project['tags'] is not none and project['tags']|length > 0 %}

--- a/rcos_io/views/projects.py
+++ b/rcos_io/views/projects.py
@@ -7,9 +7,12 @@ from flask import (
     session,
     flash,
     url_for,
+    Markup
 )
 from datetime import date
 from typing import Any, Dict, List
+import bleach
+import markdown
 
 import rcos_io.services.db as db
 import rcos_io.views.auth as auth
@@ -100,4 +103,9 @@ def project(project_id: str):
         )
     )
 
-    return render_template("projects/project.html", project=project, semester=session["semester"])
+    compiled_md = markdown.markdown(project["description_markdown"])    
+    sanitized_md = Markup(bleach.clean(compiled_md, tags=[ 
+        'b', 'i', 'p', 'h1', 'h2', 'h3', 'h4', 'h5', 'a', 'code', 'ul', 'li', 'ol', 'em', 'strong'
+    ]))
+
+    return render_template("projects/project.html", project=project, full_description=sanitized_md, semester=session["semester"])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 attrs==22.1.0
 backoff==2.2.1
 black==22.10.0
+bleach==5.0.1
 certifi==2022.9.24
 charset-normalizer==2.1.1
 click==8.1.3
@@ -10,9 +11,11 @@ gql==3.4.0
 graphql-core==3.2.3
 gunicorn==20.1.0
 idna==3.4
+importlib-metadata==5.0.0
 iniconfig==1.1.1
 itsdangerous==2.1.2
 Jinja2==3.1.2
+Markdown==3.4.1
 MarkupSafe==2.1.1
 multidict==6.0.2
 mypy-extensions==0.4.3
@@ -27,8 +30,11 @@ python-dotenv==0.21.0
 pytz==2022.5
 requests==2.28.1
 requests-toolbelt==0.10.0
+six==1.16.0
 tomli==2.0.1
 typing_extensions==4.4.0
 urllib3==1.26.12
+webencodings==0.5.1
 Werkzeug==2.2.2
 yarl==1.8.1
+zipp==3.10.0


### PR DESCRIPTION
Before feeding the rendered Markdown to the template, we now pass it through Bleach so that unwanted tags are stripped away. I currently set it to use a very basic subset of tags (bold, italics, etc...) to prevent against any cross-site scripting attacks. It's enough to render 99% of use cases, but we can amend as needed.

<img width="607" alt="image" src="https://user-images.githubusercontent.com/8661089/199369222-c456736a-a5a2-4122-8ab0-bf98eaaaa95f.png">

