### PR TITLE
Oversize Github Icon Fix

### DIFF
--- a/rcos_io/blueprints/users/templates/users/detail.html
+++ b/rcos_io/blueprints/users/templates/users/detail.html
@@ -85,7 +85,7 @@
             src="https://github.com/{{ user['github_username'] }}.png?size=48"
             alt="GitHub avatar"
             class="rounded-circle me-3"
-            style="border: 2px solid white"
+            style="border: 2px solid white; max-width: 48px"
           />
           <strong class="flex-grow-1 fs-4"
             ><a


### PR DESCRIPTION
PR: added max-width of 48px to GitHub icon on user profile to fix oversized default icons